### PR TITLE
Add workflow with self-hosted runner to test against TensorFlow image builds

### DIFF
--- a/.github/workflows/tensorflow-build-test.yaml
+++ b/.github/workflows/tensorflow-build-test.yaml
@@ -23,19 +23,6 @@ jobs:
       # Step 1 is to checkout the github repo used to build the Dockerfile
       - name: Check out the repo
         uses: actions/checkout@v3
-      # Step 2 is to login to docker hub so the image can be pushed
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        # GitHub secrets are used to provide login information to docker hub
-        with:
-          username: ${{ secrets.CCP_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.CCP_DOCKERHUB_TOKEN  }}
-      # Pull relevant metadata out of the docker image used
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: cislcloudpilot/cisl-cloud-gpu-tf
       # Get the date to apply to image tag
       - name: Get current date
         id: date
@@ -45,14 +32,11 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           # Provide the current directory as build context 
-          context: .
+          context: configs/jupyter/gpu-tf-notebook/.
           # Specify where the Dockerfile is located in relation to the repo base path
           file: configs/jupyter/gpu-tf-notebook/Dockerfile
           # Enable the push to docker hub
-          push: true
+          push: false
           # Provide the tags to apply to the image, this example uses the latest image tag 
           tags: |
-            cislcloudpilot/cisl-cloud-gpu-tf:latest
             cislcloudpilot/cisl-cloud-gpu-tf:${{ steps.date.outputs.date }}
-          # Apply labels as defined in the Docker image metadata
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tensorflow-build-test.yaml
+++ b/.github/workflows/tensorflow-build-test.yaml
@@ -1,0 +1,58 @@
+# This workflow builds docker images and pushes them to a Docker Hub Repository
+# This workflow is specific to the base-notebook directory and image
+# Set the workflow name
+name: Tensorflow Build Test
+
+# Define the trigger that starts the action
+# For this workflow the trigger is on a push that changes anything in the configs/jupyter/base-notebook/ path
+on:
+  push:
+    paths:
+      - configs/jupyter/gpu-tf-notebook/**
+    branches:
+      - dev
+
+# Define the actions that are going to take place as part of this workflow    
+jobs:
+  # Name the job(s)
+  deploy-docker-gpu-tf-notebook:
+    # Define where the job should run in this case it will be run on the latest ubuntu image
+    runs-on: self-hosted
+    # Set the steps to take in order
+    steps:
+      # Step 1 is to checkout the github repo used to build the Dockerfile
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      # Step 2 is to login to docker hub so the image can be pushed
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        # GitHub secrets are used to provide login information to docker hub
+        with:
+          username: ${{ secrets.CCP_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.CCP_DOCKERHUB_TOKEN  }}
+      # Pull relevant metadata out of the docker image used
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: cislcloudpilot/cisl-cloud-gpu-tf
+      # Get the date to apply to image tag
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d.%H')" >> $GITHUB_OUTPUT
+      # Build and push the docker image
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          # Provide the current directory as build context 
+          context: .
+          # Specify where the Dockerfile is located in relation to the repo base path
+          file: configs/jupyter/gpu-tf-notebook/Dockerfile
+          # Enable the push to docker hub
+          push: true
+          # Provide the tags to apply to the image, this example uses the latest image tag 
+          tags: |
+            cislcloudpilot/cisl-cloud-gpu-tf:latest
+            cislcloudpilot/cisl-cloud-gpu-tf:${{ steps.date.outputs.date }}
+          # Apply labels as defined in the Docker image metadata
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # CISL Cloud Pilot Project
-| GitHub Pages |  ![GitHub Pages Status](https://github.com/NCAR/cisl-cloud/actions/workflows/pages/pages-build-deployment/badge.svg) | |
+| Documentation Website Builds | ![GitHub Pages Status](https://github.com/NCAR/cisl-cloud/actions/workflows/pages/pages-build-deployment/badge.svg) | ![Documentation CI/CD Status](https://github.com/NCAR/cisl-cloud/actions/workflows/docs-cicd.yaml/badge.svg) |
 |---|---|---|
-| Documentation Website Builds | ![Documentation Test Build Status](https://github.com/NCAR/cisl-cloud/actions/workflows/docs-cicd-test.yaml/badge.svg) | ![Documentation CI/CD Status](https://github.com/NCAR/cisl-cloud/actions/workflows/docs-cicd.yaml/badge.svg) |
 | **Jupyter Singleuser CPU image build** | ![CPU Image Test Build Status](https://github.com/NCAR/cisl-cloud/actions/workflows/build-basenb-test.yaml/badge.svg) | ![CPU Image Build Status](https://github.com/NCAR/cisl-cloud/actions/workflows/build-push-basenb.yaml/badge.svg) |
 | **Jupyter Singleuser GPU image builds** | ![Tensorflow Image Build Status](https://github.com/NCAR/cisl-cloud/actions/workflows/build-push-tfgpu.yaml/badge.svg) | ![PyTorch Image Build Status](https://github.com/NCAR/cisl-cloud/actions/workflows/build-push-pytgpu.yaml/badge.svg) |
 


### PR DESCRIPTION
This PR adds a new Github Actions workflow that will run when changes are made to the configs/jupyter/gpu-tf-notebook/ directory in the dev branch. This workflow runs on a self-hosted runner that was recently deployed and this job will act primarily as a test of the self-hosted runner to start. The TensorFlow image builds are unsuccessful on the GitHub hosted runners and this PR starts progress on using self-hosted runners to build all our images instead. 

This also includes an update to the README that removes a status badge for a workflow that was removed